### PR TITLE
Add overloads for THNN LSTM and GRU RNN cells

### DIFF
--- a/aten/src/ATen/native/CheckPoint.cpp
+++ b/aten/src/ATen/native/CheckPoint.cpp
@@ -946,4 +946,55 @@ Tensor checkpoint__masked_scale(const Tensor & self, const Tensor & mask, double
   return CheckPointTensorImpl::make(rt, s)[0];
 }
 
+std::tuple<Tensor, Tensor, Tensor> checkpoint__thnn_fused_lstm_cell(const Tensor& input_gates, const Tensor& hidden_gates,
+                                                                    const Tensor& cx, const Tensor& input_bias,
+                                                                    const Tensor& hidden_bias) {
+  rematerialize_function_t rt =
+    [=](const Tensors& vec) -> Tensors {
+    auto res = at::_thnn_fused_lstm_cell(vec[0], vec[1], vec[2], vec[3], vec[4]);
+    return {std::get<0>(res), std::get<1>(res), std::get<2>(res)};
+  };
+  strongs s = {from_tensor(input_gates), from_tensor(hidden_gates), from_tensor(cx),
+               from_tensor_maybe(input_bias), from_tensor_maybe(hidden_bias)};
+  auto res = CheckPointTensorImpl::make(rt, s);
+  return {res[0], res[1], res[2]};
+}
+
+std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> checkpoint__thnn_fused_lstm_cell_backward(const Tensor& grad_hy, const Tensor& grad_cy, const Tensor& cx, const Tensor& cy, const Tensor& workspace, bool has_bias) {
+  rematerialize_function_t rt =
+    [=](const Tensors& vec) -> Tensors {
+    auto res = at::_thnn_fused_lstm_cell_backward(vec[0], vec[1], vec[2], vec[3], vec[4], has_bias);
+    return {std::get<0>(res), std::get<1>(res),
+        std::get<2>(res), std::get<3>(res), std::get<4>(res)};
+  };
+  strongs s = {from_tensor_maybe(grad_hy), from_tensor_maybe(grad_cy),
+               from_tensor(cx), from_tensor(cy), from_tensor(workspace)};
+  auto res = CheckPointTensorImpl::make(rt, s);
+  return {res[0], res[1], res[2], res[3], res[4]};
+}
+
+std::tuple<Tensor, Tensor> checkpoint__thnn_fused_gru_cell(const Tensor& input_gates, const Tensor& hidden_gates, const Tensor& hx, const Tensor& input_bias, const Tensor& hidden_bias) {
+  rematerialize_function_t rt =
+    [=](const Tensors& vec) -> Tensors {
+    auto res = at::_thnn_fused_gru_cell(vec[0], vec[1], vec[2], vec[3], vec[4]);
+    return {std::get<0>(res), std::get<1>(res)};
+  };
+  strongs s = {from_tensor(input_gates), from_tensor(hidden_gates), from_tensor(hx),
+               from_tensor_maybe(input_bias), from_tensor_maybe(hidden_bias)};
+  auto res = CheckPointTensorImpl::make(rt, s);
+  return {res[0], res[1]};
+}
+
+std::tuple<Tensor, Tensor, Tensor, Tensor, Tensor> checkpoint__thnn_fused_gru_cell_backward(const Tensor& grad_hy, const Tensor& workspace, bool has_bias) {
+  rematerialize_function_t rt =
+    [=](const Tensors& vec) -> Tensors {
+    auto res = at::_thnn_fused_gru_cell_backward(vec[0], vec[1], has_bias);
+    return {std::get<0>(res), std::get<1>(res),
+        std::get<2>(res), std::get<3>(res), std::get<4>(res)};
+  };
+  strongs s = {from_tensor(grad_hy), from_tensor(workspace)};
+  auto res = CheckPointTensorImpl::make(rt, s);
+  return {res[0], res[1], res[2], res[3], res[4]};
+}
+
 }}

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -3855,33 +3855,31 @@
 - func: _thnn_fused_lstm_cell(Tensor input_gates, Tensor hidden_gates, Tensor cx, Tensor? input_bias=None, Tensor? hidden_bias=None) -> (Tensor, Tensor, Tensor)
   dispatch:
     CUDA: _thnn_fused_lstm_cell_cuda
+    CheckPoint: checkpoint__thnn_fused_lstm_cell
 
 - func: _thnn_fused_lstm_cell_backward(Tensor? grad_hy, Tensor? grad_cy, Tensor cx, Tensor cy, Tensor workspace, bool has_bias) -> (Tensor, Tensor, Tensor, Tensor, Tensor)
   dispatch:
     CUDA: _thnn_fused_lstm_cell_backward_cuda
+    CheckPoint: checkpoint__thnn_fused_lstm_cell_backward
 
 - func: _thnn_differentiable_lstm_cell_backward(Tensor? grad_hy, Tensor? grad_cy, Tensor input_gates, Tensor hidden_gates, Tensor? input_bias, Tensor? hidden_bias, Tensor cx, Tensor cy) -> (Tensor, Tensor, Tensor, Tensor, Tensor)
 
 - func: _thnn_fused_gru_cell(Tensor input_gates, Tensor hidden_gates, Tensor hx, Tensor? input_bias=None, Tensor? hidden_bias=None) -> (Tensor, Tensor)
   dispatch:
     CUDA: _thnn_fused_gru_cell_cuda
+    CheckPoint: checkpoint__thnn_fused_gru_cell
 
 - func: _thnn_fused_gru_cell_backward(Tensor grad_hy, Tensor workspace, bool has_bias) -> (Tensor, Tensor, Tensor, Tensor, Tensor)
   dispatch:
     CUDA: _thnn_fused_gru_cell_backward_cuda
+    CheckPoint: checkpoint__thnn_fused_gru_cell_backward
 
 - func: _thnn_differentiable_gru_cell_backward(Tensor grad_hy, Tensor input_gates, Tensor hidden_gates, Tensor hx, Tensor? input_bias, Tensor? hidden_bias) -> (Tensor, Tensor, Tensor, Tensor, Tensor)
 
 # RNN cells and layers
 - func: lstm.input(Tensor input, Tensor[] hx, Tensor[] params, bool has_biases, int num_layers, float dropout, bool train, bool bidirectional, bool batch_first) -> (Tensor, Tensor, Tensor)
-  dispatch:
-    CUDA: lstm
-    CheckPoint: checkpoint_lstm
 
 - func: lstm.data(Tensor data, Tensor batch_sizes, Tensor[] hx, Tensor[] params, bool has_biases, int num_layers, float dropout, bool train, bool bidirectional) -> (Tensor, Tensor, Tensor)
-  dispatch:
-    CUDA: lstm
-    CheckPoint: checkpoint_lstm
 
 - func: gru.input(Tensor input, Tensor hx, Tensor[] params, bool has_biases, int num_layers, float dropout, bool train, bool bidirectional, bool batch_first) -> (Tensor, Tensor)
 


### PR DESCRIPTION
These overloads should allow for running the example PyTorch RNNs with CuDNN turned off