### PR TITLE
More checkpointed operators: checkpoint_mean and max_pool2d_with_indices

### DIFF
--- a/aten/src/ATen/native/CheckPoint.cpp
+++ b/aten/src/ATen/native/CheckPoint.cpp
@@ -531,19 +531,6 @@ Tensor checkpoint_prelu(Tensor const&, Tensor const&) {
   AT_ERROR("prelu");
 }
 
-Tensor checkpoint_max_pool2d(const Tensor& self, c10::ArrayRef<long> kernel_size, c10::ArrayRef<long> stride, c10::ArrayRef<long> padding, c10::ArrayRef<long> dilation, bool ceil_mode) {
-  std::vector<long> kernel_size_ = kernel_size.vec();
-  std::vector<long> stride_ = stride.vec();
-  std::vector<long> padding_ = padding.vec();
-  std::vector<long> dilation_ = dilation.vec();
-  rematerialize_function_t rt =
-    [=](const Tensors& vec) -> Tensors {
-    return {at::max_pool2d(vec[0], kernel_size_, stride_, padding_, dilation_, ceil_mode)};
-  };
-  strongs s = {from_tensor(self)};
-  return CheckPointTensorImpl::make(rt, s)[0];
-}
-
 Tensor checkpoint_max(Tensor const&) {
   AT_ERROR("max");
 }

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1771,10 +1771,6 @@
 
 - func: max_pool2d(Tensor self, int[2] kernel_size, int[2] stride=[], int[2] padding=0, int[2] dilation=1, bool ceil_mode=False) -> Tensor
   supports_named_tensor: True
-  # dispatch:
-  #   CUDA: max_pool2d
-  #   CPU: max_pool2d
-  #   CheckPoint: checkpoint_max_pool2d
 
 - func: mkldnn_max_pool2d(Tensor self, int[2] kernel_size, int[2] stride=[], int[2] padding=0, int[2] dilation=1, bool ceil_mode=False) -> Tensor
   requires_tensor: True


### PR DESCRIPTION
max_pool2d is implemented in terms of max_pool2d_with_indices so we had to overload the latter to have the former work.

These operators allow us to have the torchvision CNNs working.