### PR TITLE
Restore max pool2d overloads

### DIFF
--- a/aten/src/ATen/native/CheckPoint.cpp
+++ b/aten/src/ATen/native/CheckPoint.cpp
@@ -535,19 +535,6 @@ Tensor checkpoint_prelu(Tensor const&, Tensor const&) {
   AT_ERROR("prelu");
 }
 
-Tensor checkpoint_max_pool2d(const Tensor& self, c10::ArrayRef<long> kernel_size, c10::ArrayRef<long> stride, c10::ArrayRef<long> padding, c10::ArrayRef<long> dilation, bool ceil_mode) {
-  std::vector<long> kernel_size_ = kernel_size.vec();
-  std::vector<long> stride_ = stride.vec();
-  std::vector<long> padding_ = padding.vec();
-  std::vector<long> dilation_ = dilation.vec();
-  rematerialize_function_t rt =
-    [=](const Tensors& vec) -> Tensors {
-    return {at::max_pool2d(vec[0], kernel_size_, stride_, padding_, dilation_, ceil_mode)};
-  };
-  strongs s = {from_tensor(self)};
-  return CheckPointTensorImpl::make(rt, s)[0];
-}
-
 Tensor checkpoint_max(Tensor const&) {
   AT_ERROR("max");
 }

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -1803,10 +1803,6 @@
 
 - func: max_pool2d(Tensor self, int[2] kernel_size, int[2] stride=[], int[2] padding=0, int[2] dilation=1, bool ceil_mode=False) -> Tensor
   supports_named_tensor: True
-  # dispatch:
-  #   CUDA: max_pool2d
-  #   CPU: max_pool2d
-  #   CheckPoint: checkpoint_max_pool2d
 
 - func: mkldnn_max_pool2d(Tensor self, int[2] kernel_size, int[2] stride=[], int[2] padding=0, int[2] dilation=1, bool ceil_mode=False) -> Tensor
   requires_tensor: True


### PR DESCRIPTION
The creation of the `banishing` branch removed the overloads needed for `max_pool2d`, which is necessary for some models. This PR adds it back.

Please review @MarisaKirisame 