### PR TITLE
[hotfix] Remove attempt to clone generator (causing segfault)

### DIFF
--- a/aten/src/ATen/native/CheckPoint.cpp
+++ b/aten/src/ATen/native/CheckPoint.cpp
@@ -875,9 +875,15 @@ struct Ref {
 };
 
 std::tuple<Tensor, Tensor> checkpoint__fused_dropout(const Tensor & self, double p, Generator* g) {
-  // TODO: Figure out how to properly duplicate the generator
+  // TODO: Figure out how to properly duplicate the generator;
+  // note that the commented-out code below results in a segfault!
+  // Ref<std::shared_ptr<Generator>> gen;
   rematerialize_function_t rt =
     [=](const Tensors& vec) -> Tensors {
+    // Generator* cur = gen.t ? gen.t.get() : g;
+    // auto newG = cur->clone();
+    // auto res = at::_fused_dropout(vec[0], p, cur);
+    // gen.t = newG;
     auto res = at::_fused_dropout(vec[0], p);
     return {std::get<0>(res), std::get<1>(res)};
   };


### PR DESCRIPTION
This PR removes an attempt to clone the pseudorandom generator for the checkpointed version of `_fused_dropout`, as it causes a segfault and makes it impossible to test DTR. We should figure out the proper way to perform this operation, but a broken implementation should not be left in the codebase

Please review @MarisaKirisame 