### PR TITLE
Add overloads for Deepspeech and more for ACT

### DIFF
--- a/aten/src/ATen/native/Checkpoint.cpp
+++ b/aten/src/ATen/native/Checkpoint.cpp
@@ -1460,6 +1460,68 @@ Tensor checkpoint_hardtanh_backward(const Tensor& grad_output, const Tensor& sel
   return CheckpointTensorImpl::make("hardtanh_backward", rt, {grad_output, self})[0];
 }
 
+Tensor checkpoint_nonzero(const Tensor& self) {
+  rematerialize_function_t rt =
+    [=](const Tensors& vec) -> Tensors {
+    return {at::nonzero(vec.at(0))};
+  };
+  return CheckpointTensorImpl::make("nonzero", rt, {self})[0];
+}
+
+Tensor& checkpoint_nonzero_out(Tensor& out, const Tensor& self) {
+  mutate_function_t mt =
+    [=](const Tensors& vec) {
+    Tensor out_ = vec.at(0);
+    at::nonzero_out(out_, vec.at(1));
+  };
+  CheckpointTensorImpl::mutate("nonzero_out", mt, {out, self}, {0});
+  return {out};
+}
+
+Tensor checkpoint_lt(const Tensor& self, Scalar other) {
+  rematerialize_function_t rt =
+    [=](const Tensors& vec) -> Tensors {
+    return {at::lt(vec.at(0), other)};
+  };
+  return CheckpointTensorImpl::make("lt_Scalar", rt, {self})[0];
+}
+
+Tensor& checkpoint_lt_out(Tensor& out, const Tensor& self, Scalar other) {
+  mutate_function_t mt =
+    [=](const Tensors& vec) {
+    Tensor out_ = vec.at(0);
+    at::lt_out(out_, vec.at(1), other);
+  };
+  CheckpointTensorImpl::mutate("lt_Scalar_out", mt, {out, self}, {0});
+  return {out};
+}
+
+Tensor checkpoint_lt(const Tensor& self, const Tensor& other) {
+  rematerialize_function_t rt =
+    [=](const Tensors& vec) -> Tensors {
+    return {at::lt(vec.at(0), vec.at(1))};
+  };
+  return CheckpointTensorImpl::make("lt_Tensor", rt, {self, other})[0];
+}
+
+Tensor& checkpoint_lt_out(Tensor& out, const Tensor& self, const Tensor& other) {
+  mutate_function_t mt =
+    [=](const Tensors& vec) {
+    Tensor out_ = vec.at(0);
+    at::lt_out(out_, vec.at(1), vec.at(2));
+  };
+  CheckpointTensorImpl::mutate("lt_Tensor_out", mt, {out, self, other}, {0});
+  return {out};
+}
+
+Tensor checkpoint_any(const Tensor& self) {
+  rematerialize_function_t rt =
+    [=](const Tensors& vec) -> Tensors {
+    return {at::any(vec.at(0))};
+  };
+  return CheckpointTensorImpl::make("any", rt, {self})[0];
+}
+
 bool checkpoint__use_cudnn_ctc_loss(const Tensor& log_probs, const Tensor& targets, ArrayRef<long> input_lengths, ArrayRef<long> target_lengths, long blank) {
   return at::_use_cudnn_ctc_loss(decheckpoint(log_probs), decheckpoint(targets), input_lengths, target_lengths, blank);
 }

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -4794,6 +4794,7 @@
     CPU: lt_out
     CUDA: lt_out
     QuantizedCPU: lt_out_quantized_cpu
+    Checkpoint: checkpoint_lt_out
 
 - func: lt.Scalar(Tensor self, Scalar other) -> Tensor
   supports_named_tensor: True
@@ -4803,6 +4804,7 @@
     CPU: lt
     CUDA: lt
     QuantizedCPU: lt_quantized_cpu
+    Checkpoint: checkpoint_lt
 
 - func: lt.Tensor_out(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)
   supports_named_tensor: True
@@ -4810,6 +4812,7 @@
     CPU: lt_out
     CUDA: lt_out
     QuantizedCPU: lt_out_quantized_cpu
+    Checkpoint: checkpoint_lt_out
 
 - func: lt.Tensor(Tensor self, Tensor other) -> Tensor
   supports_named_tensor: True
@@ -4819,6 +4822,7 @@
     CPU: lt
     CUDA: lt
     QuantizedCPU: lt_quantized_cpu
+    Checkpoint: checkpoint_lt
 
 - func: take.out(Tensor self, Tensor index, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:
@@ -4871,6 +4875,7 @@
   dispatch:
     CPU: legacy::cpu::_th_nonzero_out
     CUDA: legacy::cuda::_th_nonzero_out
+    Checkpoint: checkpoint_nonzero_out
 
 - func: nonzero(Tensor self) -> Tensor
   use_c10_dispatcher: full
@@ -4878,6 +4883,7 @@
   dispatch:
     CPU: legacy::cpu::_th_nonzero
     CUDA: legacy::cuda::_th_nonzero
+    Checkpoint: checkpoint_nonzero
 
 - func: nonzero_numpy(Tensor self) -> Tensor[]
   variants: method, function
@@ -5379,6 +5385,7 @@
     CUDA: any
     SparseCPU: any_sparse
     SparseCUDA: any_sparse
+    Checkpoint: checkpoint_any
 
 - func: renorm.out(Tensor self, Scalar p, int dim, Scalar maxnorm, *, Tensor(a!) out) -> Tensor(a!)
   dispatch:


### PR DESCRIPTION
Overloads I needed to support Deepspeech (I had to add some non-CuDNN overloads because it does some weird memory layout stuff when CuDNN is enabled, I'm also pretty sure it would otherwise use CuDNN's "all in one" RNN implementation)