### PR TITLE
Checkpoint untracked constants to avoid stitching

### DIFF
--- a/aten/src/ATen/CheckpointTensorImpl.h
+++ b/aten/src/ATen/CheckpointTensorImpl.h
@@ -150,20 +150,16 @@ struct Rematerializer : intrusive_ptr_target {
   // because they dont have rematerializer it will never get evicted.
   // We should probably refactor and fix this, but it will take some nontrivial effort.
   strongs input_values;
-  std::vector<std::tuple<Tensor, size_t>> constants;
   weaks outputs;
   rematerialize_function_t func;
   Rematerializer(const Unsafe&,
                  const strongs& input_values,
-                 const std::vector<std::tuple<Tensor, size_t>>& constants,
                  const rematerialize_function_t& func)  :
     input_values(input_values),
-    constants(constants),
     func(func) {
   }
   void release_resources() final {
     input_values.clear();
-    constants.clear();
     outputs.clear();
     func = rematerialize_function_t();
   }

--- a/aten/src/ATen/Logger.h
+++ b/aten/src/ATen/Logger.h
@@ -45,7 +45,6 @@ const std::string MEMORY = "MEMORY";
 const std::string ALIAS = "ALIAS";
 const std::string NAME = "NAME";
 const std::string CONSTANT = "CONSTANT";
-const std::string CONSTANTS = "CONSTANTS";
 
 void DTRLogConstant(const std::string& name) {
   if (log_json) {
@@ -108,7 +107,6 @@ void DTRLogCopy(const std::string& new_name, const std::string& old_name) {
 
 void DTRLogMutate(const std::string& name,
                   const std::vector<std::string>& args,
-                  const std::vector<size_t>& constants,
                   const std::vector<size_t>& mutate,
                   const std::string& time) {
   if (log_json) {
@@ -116,12 +114,10 @@ void DTRLogMutate(const std::string& name,
     j[INSTRUCTION] = "MUTATE";
     j[NAME] = name;
     j[ARGS] = args;
-    j[CONSTANTS] = constants;
     j["MUTATE"] = mutate;
     j[TIME] = time;
     DTRLogger::logger().log(j.dump());
   } else {
-    CHECK(constants.size() == 0); //TODO: implement.
     std::string log = name;
     log += "(";
     for (const auto& s : args) {
@@ -157,7 +153,6 @@ void DTRLogRelease(const std::string& counter_name) {
 void DTRLogCall(const std::vector<std::string>& res,
                 const std::string& name,
                 const std::vector<std::string>& args,
-                const std::vector<size_t>& constants,
                 const std::string& time) {
   if (log_json) {
     json j;
@@ -165,11 +160,9 @@ void DTRLogCall(const std::vector<std::string>& res,
     j[NAME] = name;
     j["RESULT"] = res;
     j[ARGS] = args;
-    j[CONSTANTS] = constants;
     j[TIME] = time;
     DTRLogger::logger().log(j.dump());
   } else {
-    CHECK(constants.size() == 0); //TODO: implement.
     std::string arg = name + "(";
     for (const auto& s : args) {
       arg += s;


### PR DESCRIPTION
I added a function that checks if each input to a function or mutation is a checkpointed tensor. If not, it creates a new checkpointed tensor and uses that as input instead. If I understand what's going on correctly, this should ensure that there will not be any more untracked constants in our logs. I ran this and it does not cause any problems in our currently supported models.

Please review @MarisaKirisame @altanh 
