### PR TITLE
Add off switches for random sampling and ignoring small tensors

### DIFF
--- a/aten/src/ATen/CheckpointTensorImpl.cpp
+++ b/aten/src/ATen/CheckpointTensorImpl.cpp
@@ -135,7 +135,7 @@ long cost_time_ = 0;
 
 CheckpointPool pool;
 void CheckpointPool::add(const intrusive_ptr<AliasPool>& p) {
-  if (p->memory > 0 && (memory_count == 0 || p->memory >= 0.01 * double(memory_sum/memory_count))) {
+  if (p->memory > 0 && (memory_count == 0 || !ignore_small_tensors || p->memory >= 0.01 * double(memory_sum/memory_count))) {
     aps.push_back(weak_intrusive_ptr<AliasPool>(p));
   }
 }
@@ -296,12 +296,12 @@ void set_memory_budget(long budget) {
   pool.has_memory_budget = true;
 }
 
-void enable_sampling() {
-  pool.sample_tensors = true;
+void toggle_sampling(bool sample) {
+  pool.sample_tensors = sample;
 }
 
-void disable_sampling() {
-  pool.sample_tensors = false;
+void toggle_ignore_small_tensors(bool ignore) {
+  pool.ignore_small_tensors = ignore;
 }
 
 void reset_profile() {

--- a/aten/src/ATen/CheckpointTensorImpl.h
+++ b/aten/src/ATen/CheckpointTensorImpl.h
@@ -445,6 +445,8 @@ struct CheckpointPool {
   std::mt19937 gen = std::mt19937(rd());
   // whether to take a square-root sample of the pool during an eviction loop
   bool sample_tensors = true;
+  // ignore tensors < 1% of the average tensor size
+  bool ignore_small_tensors = true;
   bool has_memory_budget = false;
   long memory_budget;
   void evict();

--- a/aten/src/ATen/native/native_functions.yaml
+++ b/aten/src/ATen/native/native_functions.yaml
@@ -48,10 +48,10 @@
 - func: unset_memory_budget() -> ()
   variants: function
 
-- func: enable_sampling() -> ()
+- func: toggle_sampling(bool sample) -> ()
   variants: function
 
-- func: disable_sampling() -> ()
+- func: toggle_ignore_small_tensors(bool ignore) -> ()
   variants: function
 
 - func: reset_profile() -> ()


### PR DESCRIPTION
This should allow for easily checking the performance impact of random sampling, particularly since it seems to affect reliability at lower budgets. It's a pretty simple switch.

Please review, @MarisaKirisame.